### PR TITLE
9/escape characters in labels

### DIFF
--- a/entities/dotClass.py
+++ b/entities/dotClass.py
@@ -21,7 +21,8 @@ class DotMemberVariable:
 
 class DotClass:
     def __init__(self, name: str, filepath: str, line_num: int):
-        self.name = name
+        self.class_label = name
+        self.name = name.replace(':', '_')
         self.filepath = filepath
         self.line_num = line_num
         self.member_variables: tp.List[DotMemberVariable] = []
@@ -39,7 +40,7 @@ class DotClass:
 
     def __str__(self) -> str:
         ans = "    subgraph cluster_" + self.name + " {\n"
-        ans += f'        label="class {self.name}\\n{self.filepath} {self.line_num}"\n'
+        ans += f'        label="class {self.class_label}\\n{self.filepath} {self.line_num}"\n'
         if self.member_variables:
             ans += \
 f"""

--- a/entities/dotClass.py
+++ b/entities/dotClass.py
@@ -1,5 +1,5 @@
 import typing as tp
-from entities.dotFunction import DotFunction, escape_angular_brackets
+from entities.dotFunction import DotFunction, substitute_angular_brackets_after_escaping
 
 class DotMemberVariable:
     def __init__(self, name: str, var_type: str=None, line_num: int=None, label: str=None):
@@ -16,7 +16,7 @@ class DotMemberVariable:
     def __str__(self) -> str:
         line_num_str = f"<BR/>{self.line_num}" if self.line_num \
                        else ""
-        escaped_label = escape_angular_brackets(self.label)
+        escaped_label = substitute_angular_brackets_after_escaping(self.label)
         return " "*12 + f'<TR><TD PORT="{self.name}">{escaped_label}{line_num_str}</TD></TR>\n'
 
 class DotClass:

--- a/entities/dotFunction.py
+++ b/entities/dotFunction.py
@@ -5,7 +5,7 @@ def escape_angular_brackets(label: str) -> str:
 
 def substitute_angular_brackets_after_escaping(label: str) -> str:
     return escape_angular_brackets(label)\
-            .replace('[[', '<').replace(']]', '>')
+            .replace('[[', '<').replace(']]', '>').replace('\\n', '<BR/>')
 
 class DotParam:
     def __init__(self, name: str, var_type: str=None, label: str=None):

--- a/entities/dotFunction.py
+++ b/entities/dotFunction.py
@@ -3,6 +3,10 @@ import typing as tp
 def escape_angular_brackets(label: str) -> str:
     return label.replace('<', '&lt;').replace('>', '&gt;')
 
+def substitute_angular_brackets_after_escaping(label: str) -> str:
+    return escape_angular_brackets(label)\
+            .replace('[[', '<').replace(']]', '>')
+
 class DotParam:
     def __init__(self, name: str, var_type: str=None, label: str=None):
         self.name = name
@@ -15,7 +19,7 @@ class DotParam:
                 self.label = name
 
     def __str__(self) -> str:
-        escaped_label = escape_angular_brackets(self.label)
+        escaped_label = substitute_angular_brackets_after_escaping(self.label)
         return " "*12 + f'<TR><TD PORT="{self.name}">{escaped_label}</TD></TR>\n'
 
 class DotFunction:
@@ -36,7 +40,7 @@ class DotFunction:
     def __str__(self) -> str:
         line_num_str = f"<BR/>{self.line_num}" if self.line_num \
                        else ""
-        escaped_label = escape_angular_brackets(self.label)
+        escaped_label = substitute_angular_brackets_after_escaping(self.label)
         ans = \
 f"""
         {self.name} [shape="none" label=<
@@ -46,7 +50,7 @@ f"""
         for p in self.params:
             ans += str(p)
         if self.retval:
-            escaped_retval = escape_angular_brackets(self.retval)
+            escaped_retval = substitute_angular_brackets_after_escaping(self.retval)
             ans += f'            <TR><TD PORT="retval"><B>returns</B> {escaped_retval}</TD></TR>\n'
         ans += "        </TABLE>>]\n"
         return ans

--- a/entities/tests/expectations/test_class_with_colon_in_name.txt
+++ b/entities/tests/expectations/test_class_with_colon_in_name.txt
@@ -1,0 +1,14 @@
+    subgraph cluster_Entity__SomeActor {
+        label="class Entity::SomeActor\npath/to/actor.cc 146"
+
+        Entity__SomeActor_mem_var [shape="cylinder" label=<
+        <TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
+            <TR><TD PORT="count">int count<BR/>15</TD></TR>
+        </TABLE>>]
+
+        Entity__SomeActor_doSomething [shape="none" label=<
+        <TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
+            <TR><TD PORT="call">doSomething()<BR/>30</TD></TR>
+            <TR><TD PORT="retval"><B>returns</B> Namespace::doSomething()</TD></TR>
+        </TABLE>>]
+    }

--- a/entities/tests/expectations/test_class_with_member_variables.txt
+++ b/entities/tests/expectations/test_class_with_member_variables.txt
@@ -3,7 +3,7 @@
 
         SomeActor_mem_var [shape="cylinder" label=<
         <TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
-            <TR><TD PORT="SomeActor_count">int SomeActor_count<BR/>15</TD></TR>
-            <TR><TD PORT="SomeActor_name">const char * SomeActor_name<BR/>16</TD></TR>
+            <TR><TD PORT="count">int count<BR/>15</TD></TR>
+            <TR><TD PORT="name">const char * name<BR/>16</TD></TR>
         </TABLE>>]
     }

--- a/entities/tests/expectations/test_class_with_method_needing_escapes.txt
+++ b/entities/tests/expectations/test_class_with_method_needing_escapes.txt
@@ -1,0 +1,9 @@
+    subgraph cluster_SomeActor {
+        label="class SomeActor\npath/to/actor.cc 146"
+
+        SomeActor_doSomething [shape="none" label=<
+        <TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
+            <TR><TD PORT="call">doSomething()<BR/>30</TD></TR>
+            <TR><TD PORT="retval"><B>returns</B> Namespace::<B>do</B>Something&lt;B&gt;()</TD></TR>
+        </TABLE>>]
+    }

--- a/entities/tests/expectations/test_class_with_method_needing_escapes.txt
+++ b/entities/tests/expectations/test_class_with_method_needing_escapes.txt
@@ -4,6 +4,6 @@
         SomeActor_doSomething [shape="none" label=<
         <TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
             <TR><TD PORT="call">doSomething()<BR/>30</TD></TR>
-            <TR><TD PORT="retval"><B>returns</B> Namespace::<B>do</B>Something&lt;B&gt;()</TD></TR>
+            <TR><TD PORT="retval"><B>returns</B> Namespace::<B>do</B>Something<BR/>&lt;B&gt;()</TD></TR>
         </TABLE>>]
     }

--- a/entities/tests/expectations/test_class_with_methods.txt
+++ b/entities/tests/expectations/test_class_with_methods.txt
@@ -3,7 +3,8 @@
 
         SomeActor_doSomething [shape="none" label=<
         <TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
-            <TR><TD PORT="call">Namespace::doSomething()<BR/>30</TD></TR>
+            <TR><TD PORT="call">doSomething()<BR/>30</TD></TR>
+            <TR><TD PORT="retval"><B>returns</B> Namespace::doSomething()</TD></TR>
         </TABLE>>]
 
         SomeActor_incrCount [shape="none" label=<

--- a/entities/tests/test_dotClass.py
+++ b/entities/tests/test_dotClass.py
@@ -12,7 +12,7 @@ class TestDotClass(unittest.TestCase):
     def check_expectations(self, c: DotClass) -> None:
         caller_name = inspect.stack()[1].function
         with open(expectations_dir / f'{caller_name}.txt', 'r') as expF:
-            self.assertTrue(str(c), expF.read())
+            self.assertEqual(str(c), expF.read())
 
     def update_expectations(self, c: DotClass) -> None:
         caller_name = inspect.stack()[1].function

--- a/entities/tests/test_dotClass.py
+++ b/entities/tests/test_dotClass.py
@@ -48,3 +48,10 @@ class TestDotClass(unittest.TestCase):
         self.check_expectations(c)
 
         self.assertFalse(c.empty(), msg="DotClass should not be empty as something was added")
+
+    def test_class_with_colon_in_name(self) -> None:
+        c = DotClass("Entity::SomeActor", "path/to/actor.cc", 146)
+        c.add_member_variable("count", "int", 15)
+        f = DotFunction("doSomething", 30, "Namespace::doSomething()")
+        c.add_method(f)
+        self.check_expectations(c)

--- a/entities/tests/test_dotClass.py
+++ b/entities/tests/test_dotClass.py
@@ -49,6 +49,12 @@ class TestDotClass(unittest.TestCase):
 
         self.assertFalse(c.empty(), msg="DotClass should not be empty as something was added")
 
+    def test_class_with_method_needing_escapes(self) -> None:
+        c = DotClass("SomeActor", "path/to/actor.cc", 146)
+        f1 = DotFunction("doSomething", 30, "Namespace::[[B]]do[[/B]]Something<B>()")
+        c.add_method(f1)
+        self.update_expectations(c)
+
     def test_class_with_colon_in_name(self) -> None:
         c = DotClass("Entity::SomeActor", "path/to/actor.cc", 146)
         c.add_member_variable("count", "int", 15)

--- a/entities/tests/test_dotClass.py
+++ b/entities/tests/test_dotClass.py
@@ -51,9 +51,9 @@ class TestDotClass(unittest.TestCase):
 
     def test_class_with_method_needing_escapes(self) -> None:
         c = DotClass("SomeActor", "path/to/actor.cc", 146)
-        f1 = DotFunction("doSomething", 30, "Namespace::[[B]]do[[/B]]Something<B>()")
+        f1 = DotFunction("doSomething", 30, "Namespace::[[B]]do[[/B]]Something\\n<B>()")
         c.add_method(f1)
-        self.update_expectations(c)
+        self.check_expectations(c)
 
     def test_class_with_colon_in_name(self) -> None:
         c = DotClass("Entity::SomeActor", "path/to/actor.cc", 146)

--- a/flow.py
+++ b/flow.py
@@ -23,7 +23,7 @@ def generate_input_files(filename_prefix: str):
         outF.write(
 """# Example:
 # School path/to/school.cc 15
-# - ctor 16 | constructor
+# - ctor 16 | [[B]]cons[[/B]]tructor<B>
 # _ name std::string
 # _ students std::list<Person>
 # - enrol_student 18 @ void

--- a/flow.py
+++ b/flow.py
@@ -23,7 +23,7 @@ def generate_input_files(filename_prefix: str):
         outF.write(
 """# Example:
 # School path/to/school.cc 15
-# - ctor 16 | [[B]]cons[[/B]]tructor<B>
+# - ctor 16 | [[B]]cons[[/B]]tructor\\n<B>
 # _ name std::string
 # _ students std::list<Person>
 # - enrol_student 18 @ void

--- a/parsers/link.py
+++ b/parsers/link.py
@@ -29,10 +29,11 @@ class LinkParser:
             self.tags = tokens[0].strip()
 
     def parse_file(self, filename: str) -> None:
-        def parse_optional_port(line):
+        def parse_src_or_dst(line):
             tokens = line.split(' ')
             if len(tokens) > 2:
                 raise Exception(f"Too many spaces in line while specifying src or dst:\n{line}")
+            tokens[0] = tokens[0].replace(':', '_')
             return ':'.join(tokens)
 
         with open(filename, "r") as inF:
@@ -44,9 +45,9 @@ class LinkParser:
                     self._finish_link(i)
                 else:
                     if self.src is None:
-                        self.src = parse_optional_port(stripped_line)
+                        self.src = parse_src_or_dst(stripped_line)
                     elif self.dst is None:
-                        self.dst = parse_optional_port(stripped_line)
+                        self.dst = parse_src_or_dst(stripped_line)
                     elif self.label is None:
                         self._parse_tags_and_label(stripped_line)
                     else:

--- a/parsers/tests/inputs/link_parser/test_parse_colon_in_link.txt
+++ b/parsers/tests/inputs/link_parser/test_parse_colon_in_link.txt
@@ -1,0 +1,3 @@
+abc::vda call
+def
+some label text

--- a/parsers/tests/test_link_parser.py
+++ b/parsers/tests/test_link_parser.py
@@ -30,3 +30,11 @@ class TestLinkParser(unittest.TestCase):
             self.parse_test_input()
         self.assertTrue("Incomplete link detected" in str(ex.exception), msg= \
             "Exception message does not describe problem")
+
+    def test_parse_colon_in_link(self) -> None:
+        self.parse_test_input()
+
+        self.assertEqual(1, len(self.parser.finished_links), msg= \
+            "Should have parsed expected number of links")
+        self.assertEqual("abc__vda:call", self.parser.finished_links[0].src, msg= \
+            "First link should have replaced : for _ and then put : for the port in the src")


### PR DESCRIPTION
Issue #9: Escape `:`, unescape `<`/`>` when desired for HTML tags