### PR TITLE
14/represent loops

### DIFF
--- a/entities/dotFunction.py
+++ b/entities/dotFunction.py
@@ -27,6 +27,11 @@ class DotLocalVar(DotParam):
         escaped_label = substitute_angular_brackets_after_escaping(self.label)
         return " "*12 + f'<TR><TD PORT="{self.name}"><B>local</B> {escaped_label}</TD></TR>\n'
 
+class DotLoop(DotParam):
+    def __str__(self) -> str:
+        escaped_label = substitute_angular_brackets_after_escaping(self.label)
+        return " "*12 + f'<TR><TD PORT="{self.name}"><U>loop</U> {escaped_label}</TD></TR>\n'
+
 class DotFunction:
     def __init__(self, name: str, line_num: int=None, retval: str=None, label: str=None):
         self.name = name
@@ -38,6 +43,7 @@ class DotFunction:
         self.retval = retval
         self.params: tp.List[DotParam] = []
         self.localvars: tp.List[DotLocalVar] = []
+        self.loops: tp.List[DotLoop] = []
 
     def add_param(self, name: str, var_type: str=None) -> None:
         label = f"{var_type} {name}" if var_type else "name"
@@ -46,6 +52,12 @@ class DotFunction:
     def add_local_var(self, name: str, var_type: str=None) -> None:
         label = f"{var_type} {name}" if var_type else "name"
         self.localvars.append( DotLocalVar(name, label=label) )
+
+    def add_loop(self, name: str, line_num: str=None) -> None:
+        label = name
+        if line_num:
+            label += f" {line_num}"
+        self.loops.append( DotLoop(name, label=label) )
 
     def __str__(self) -> str:
         line_num_str = f"<BR/>{self.line_num}" if self.line_num \
@@ -61,6 +73,8 @@ f"""
             ans += str(p)
         for v in self.localvars:
             ans += str(v)
+        for l in self.loops:
+            ans += str(l)
         if self.retval:
             escaped_retval = substitute_angular_brackets_after_escaping(self.retval)
             ans += f'            <TR><TD PORT="retval"><B>returns</B> {escaped_retval}</TD></TR>\n'

--- a/entities/tests/expectations/test_class_with_method_having_loop.txt
+++ b/entities/tests/expectations/test_class_with_method_having_loop.txt
@@ -1,0 +1,11 @@
+    subgraph cluster_SomeActor {
+        label="class SomeActor\npath/to/actor.cc 146"
+
+        SomeActor_doSomething [shape="none" label=<
+        <TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
+            <TR><TD PORT="call">Namespace::<B>do</B>Something<BR/>&lt;B&gt;()<BR/>30</TD></TR>
+            <TR><TD PORT="count">int count</TD></TR>
+            <TR><TD PORT="while"><U>loop</U> while 34</TD></TR>
+            <TR><TD PORT="retval"><B>returns</B> bool</TD></TR>
+        </TABLE>>]
+    }

--- a/entities/tests/test_dotClass.py
+++ b/entities/tests/test_dotClass.py
@@ -69,3 +69,11 @@ class TestDotClass(unittest.TestCase):
         f.add_local_var("sum", "int")
         c.add_method(f)
         self.check_expectations(c)
+
+    def test_class_with_method_having_loop(self) -> None:
+        c = DotClass("SomeActor", "path/to/actor.cc", 146)
+        f = DotFunction("doSomething", 30, retval="bool", label="Namespace::[[B]]do[[/B]]Something\\n<B>()")
+        f.add_param("count", "int")
+        f.add_loop("while", 34)
+        c.add_method(f)
+        self.check_expectations(c)

--- a/flow.py
+++ b/flow.py
@@ -31,6 +31,7 @@ def generate_input_files(filename_prefix: str):
 # - is_student 20 @ bool
 # $ name std::string
 # & temp_var bool
+# ( while_not_exiting 24
 
 """
         )

--- a/parsers/node.py
+++ b/parsers/node.py
@@ -81,16 +81,23 @@ class NodeParser:
     def _parse_param(self, line: str) -> None:
         tokens = line[2:].split(' ')
         if len(tokens) != 2:
-            raise Exception(f"Wrong number of tokens when parsing a member variable:\n{line}")
+            raise Exception(f"Wrong number of tokens when parsing a param:\n{line}")
 
         self.current_function.add_param(name=tokens[0].strip(), var_type=tokens[1].strip())
 
     def _parse_local_var(self, line: str) -> None:
         tokens = line[2:].split(' ')
         if len(tokens) != 2:
-            raise Exception(f"Wrong number of tokens when parsing a member variable:\n{line}")
+            raise Exception(f"Wrong number of tokens when parsing a local var:\n{line}")
 
         self.current_function.add_local_var(name=tokens[0].strip(), var_type=tokens[1].strip())
+
+    def _parse_loop(self, line: str) -> None:
+        tokens = line[2:].split(' ')
+        if len(tokens) != 2:
+            raise Exception(f"Wrong number of tokens when parsing a loop:\n{line}")
+
+        self.current_function.add_loop(name=tokens[0].strip(), line_num=tokens[1].strip())
 
     def parse_file(self, filename: str) -> None:
         with open(filename, "r") as inF:
@@ -113,6 +120,9 @@ class NodeParser:
                 elif stripped_line.startswith("& "):
                     self._check_current_function_exists(stripped_line)
                     self._parse_local_var(stripped_line)
+                elif stripped_line.startswith("( "):
+                    self._check_current_function_exists(stripped_line)
+                    self._parse_loop(stripped_line)
                 else:
                     self._finish_class()
                     self._start_class(stripped_line)

--- a/parsers/tests/inputs/node_parser/test_parse_method_with_details.txt
+++ b/parsers/tests/inputs/node_parser/test_parse_method_with_details.txt
@@ -3,3 +3,4 @@ SomeActor path/to/actor.cc 12
 $ count int
 $ verbose bool
 & sum int
+( while_not_exiting 15

--- a/parsers/tests/test_node_parser.py
+++ b/parsers/tests/test_node_parser.py
@@ -66,3 +66,5 @@ class TestNodeParser(unittest.TestCase):
             "First method of first class should have expected number of params")
         self.assertEqual(1, len(method0.localvars), msg= \
             "First method of first class should have expected number of local variables")
+        self.assertEqual(1, len(method0.loops), msg= \
+            "First method of first class should have expected number of loops")


### PR DESCRIPTION
Issue #14: Parse `( ` lines as loops, to be written in DOT as another table row when printing `DotFunction` objects.