### PR TITLE
Issue #16: DotFunctions can now be without a DotClass

### DIFF
--- a/flow.py
+++ b/flow.py
@@ -5,6 +5,7 @@ from parsers.node import NodeParser
 from parsers.link import LinkParser
 
 from entities.dotClass import DotClass
+from entities.dotFunction import DotFunction
 from entities.dotLink import DotLink
 
 def setup_parser() -> argparse.ArgumentParser:
@@ -55,7 +56,8 @@ def parse_files(filename_prefix: str) -> tp.Tuple[NodeParser, LinkParser]:
 
     return node_p, link_p
 
-def write_translation_to_dot(nodes: tp.List[DotClass], links: tp.List[DotLink]) -> str:
+def write_translation_to_dot(nodes: tp.List[tp.Union[DotClass, DotFunction]], \
+                             links: tp.List[DotLink]) -> str:
     ans = \
 """digraph {
     rankdir=TD
@@ -75,4 +77,5 @@ if __name__ == '__main__':
         generate_input_files(args.filename_prefix)
     else:
         node_p, link_p = parse_files(args.filename_prefix)
-        print(write_translation_to_dot(node_p.finished_classes, link_p.finished_links))
+        nodes = node_p.finished_classes + node_p.standalone_functions
+        print(write_translation_to_dot(nodes, link_p.finished_links))

--- a/parsers/tests/test_node_parser.py
+++ b/parsers/tests/test_node_parser.py
@@ -40,10 +40,11 @@ class TestNodeParser(unittest.TestCase):
             msg=f"Exception message does not explain problem:\n  {ex.exception}")
 
     def test_method_without_class(self) -> None:
-        with self.assertRaises(Exception) as ex:
-            self.parse_test_input()
-        self.assertTrue("Expected a class to parse this line under" in str(ex.exception), \
-            msg=f"Exception message does not explain problem:\n  {ex.exception}")
+        self.parse_test_input()
+        self.assertEqual(0, len(self.parser.finished_classes), msg= \
+            "Should have parsed correct number of classes")
+        self.assertEqual(1, len(self.parser.standalone_functions), msg= \
+            "Should have parsed expected number of standalone functions")
 
     def test_class_broken_by_blank_line(self) -> None:
         with self.assertRaises(Exception) as ex:


### PR DESCRIPTION
Issue #16: `DotFunction` can now be without a preceding `DotClass`