### PR TITLE
24/rank same

### DIFF
--- a/combined_flow.py
+++ b/combined_flow.py
@@ -37,6 +37,8 @@ def generate_input_files(filenames: tp.List[str]):
 #
 # < Person_mem_var name
 # > School_is_student name | style="dashed, bold" color=red | 132
+#
+# @ School_ctor School_is_student
 
 """
             )
@@ -50,17 +52,23 @@ def parse_files(filenames: tp.List[str]) -> CombinedParser:
     return comb_p
 
 def write_translation_to_dot(nodes: tp.List[tp.Union[DotClass, DotFunction]], \
-                             links: tp.List[DotLink]) -> str:
+                             links: tp.List[DotLink], \
+                             rank_same_clusters: tp.Optional[tp.List[str]]) -> str:
     ans = \
 """digraph {
     rankdir=TD
     node [shape="box" style="filled" fillcolor="white"]
 """
+    if rank_same_clusters is not None:
+        ans += "    newrank=true\n"
     for node in nodes:
         ans += f"\n{node}"
     ans += "\n"
     for link in links:
         ans += str(link)
+    if rank_same_clusters:
+        for line in rank_same_clusters:
+            ans += "    { " + line + " }\n"
     ans += "}"
     return ans
 
@@ -70,4 +78,4 @@ if __name__ == '__main__':
         generate_input_files(args.filenames)
     else:
         comb_p = parse_files(args.filenames)
-        print(write_translation_to_dot(comb_p.nodes, comb_p.links))
+        print(write_translation_to_dot(comb_p.nodes, comb_p.links, comb_p.node_parser.rank_same_clusters))

--- a/parsers/node.py
+++ b/parsers/node.py
@@ -10,6 +10,7 @@ class NodeParser:
         self.finished_classes: tp.Dict[str, DotClass] = {}
         self.standalone_functions: tp.List[DotFunction] = []
         self.line_num: int = None
+        self.rank_same_clusters: tp.List[str] = None
 
     @property
     def nodes(self) -> tp.List[tp.Union[DotClass, DotFunction]]:
@@ -142,6 +143,13 @@ class NodeParser:
             else:
                 raise Exception(f"Expected a class or function to parse this line under:\n{self.line_num}: {line}")
 
+    def _parse_rank_same_cluster(self, line: str) -> None:
+        tokens = line[1:].split(' ')
+        if self.rank_same_clusters is None:
+            self.rank_same_clusters = []
+        if len(tokens) > 1:
+            self.rank_same_clusters.append(f"rank=same;{';'.join(tokens)}")
+
     def parse_stripped_line(self, line_num: int, stripped_line: str):
         self.line_num = line_num
         if stripped_line.startswith("_ "):
@@ -161,6 +169,8 @@ class NodeParser:
             self._parse_loop(stripped_line)
         elif stripped_line.startswith("= "):
             self._parse_tags_for_function_or_class(stripped_line)
+        elif stripped_line.startswith("@"):
+            self._parse_rank_same_cluster(stripped_line)
         else:
             self._finish_class()
             self._start_class(stripped_line)

--- a/parsers/node.py
+++ b/parsers/node.py
@@ -144,7 +144,7 @@ class NodeParser:
                 raise Exception(f"Expected a class or function to parse this line under:\n{self.line_num}: {line}")
 
     def _parse_rank_same_cluster(self, line: str) -> None:
-        tokens = line[1:].split(' ')
+        tokens = [t for t in line[1:].strip().split(' ') if t]
         if self.rank_same_clusters is None:
             self.rank_same_clusters = []
         if len(tokens) > 1:


### PR DESCRIPTION
New `@` sigil. Can be used standalone to start `newrank=true`. Additional space-separated node names become same-ranked.