### PR TITLE
21/triple link

### DIFF
--- a/parsers/multi_links.py
+++ b/parsers/multi_links.py
@@ -22,8 +22,14 @@ class MultiLinkParser:
 
         for dstdata in self.current_dsts_data:
             for src in self.current_srcs:
-                link = DotLink(src, dstdata.dst, dstdata.tags, dstdata.label)
-                self.finished_links.append(link)
+                if dstdata.label.startswith('** '):
+                    link_label = dstdata.label[3:]
+                    link = DotLink(src, dstdata.dst, dstdata.tags, link_label)
+                    for i in range(3):
+                        self.finished_links.append(link)
+                else:
+                    link = DotLink(src, dstdata.dst, dstdata.tags, dstdata.label)
+                    self.finished_links.append(link)
         self.current_dsts_data = []
         self.current_srcs = []
 

--- a/parsers/multi_links.py
+++ b/parsers/multi_links.py
@@ -22,8 +22,8 @@ class MultiLinkParser:
 
         for dstdata in self.current_dsts_data:
             for src in self.current_srcs:
-                if dstdata.label.startswith('** '):
-                    link_label = dstdata.label[3:]
+                if dstdata.label is not None and dstdata.label.startswith('**'):
+                    link_label = dstdata.label[2:].strip()
                     link = DotLink(src, dstdata.dst, dstdata.tags, link_label)
                     for i in range(3):
                         self.finished_links.append(link)

--- a/parsers/multi_links.py
+++ b/parsers/multi_links.py
@@ -42,7 +42,12 @@ class MultiLinkParser:
     def _add_src(self, line_num: int, line: str):
         if self.current_dsts_data:
             raise Exception(f"Finish current links before adding new sources:\n{line_num}: {line}")
-        formatted_src = self._format_link_identifier( line.split(' ') )
+
+        try:
+            formatted_src = self._format_link_identifier( line.split(' ') )
+        except Exception as ex:
+            raise Exception(f"{ex}\n{line_num}: {line}")
+
         self.current_srcs.append(formatted_src)
 
     def _add_dst(self, line_num: int, line: str):

--- a/parsers/tests/inputs/combined_parser/test_parse_two_classes_with_rank_same.txt
+++ b/parsers/tests/inputs/combined_parser/test_parse_two_classes_with_rank_same.txt
@@ -1,0 +1,18 @@
+Namespace::SomeActor path/to/actor.cc 12
+- ctor 13
+$ count int
+_ count int 17
+_ isValid bool | <B>important</B> isValid
+- incrCount 25
+
+Namespace::GreatStruct path/to/some_struct.cc 15
+_ count int 17
+_ name str 18
+_ flag bool 19
+- calculateSomething 20
+
+< Namespace__SomeActor_ctor
+<> Namespace__GreatStruct_calculateSomething
+> Namespace__SomeActor_mem_var isValid | style=dotted |
+
+@ Namespace__GreatStruct_calculateSomething Namespace__SomeActor_mem_var

--- a/parsers/tests/inputs/combined_parser/test_parse_two_classes_with_triple_links.txt
+++ b/parsers/tests/inputs/combined_parser/test_parse_two_classes_with_triple_links.txt
@@ -1,0 +1,16 @@
+Namespace::SomeActor path/to/actor.cc 12
+- ctor 13
+$ count int
+_ count int 17
+_ isValid bool | <B>important</B> isValid
+- incrCount 25
+
+Namespace::GreatStruct path/to/some_struct.cc 15
+_ count int 17
+_ name str 18
+_ flag bool 19
+- calculateSomething 20
+
+< Namespace__SomeActor_ctor
+<> Namespace__GreatStruct_calculateSomething
+> Namespace__SomeActor_mem_var isValid | style=dotted | **

--- a/parsers/tests/test_combined_parser.py
+++ b/parsers/tests/test_combined_parser.py
@@ -92,3 +92,14 @@ class TestCombinedParser(unittest.TestCase):
         class0 = finished_classes["Namespace__SomeActor"]
         self.assertEqual(2, len(class0.methods), msg= \
             "This class should have expected number of methods")
+
+    def test_parse_two_classes_with_triple_links(self) -> None:
+        self.parse_test_input()
+
+        finished_links = self.parser.link_parser.finished_links
+        self.assertEqual(4, len(finished_links), msg= \
+            "Should have parsed correct number of links")
+
+        link_tails = [str(l).split('->')[1].strip() for l in finished_links]
+        self.assertEqual(3, link_tails.count("Namespace__SomeActor_mem_var:isValid [style=dotted]"), msg= \
+            "Should have parsed correct number of links which end on this node with no label")

--- a/parsers/tests/test_combined_parser.py
+++ b/parsers/tests/test_combined_parser.py
@@ -103,3 +103,12 @@ class TestCombinedParser(unittest.TestCase):
         link_tails = [str(l).split('->')[1].strip() for l in finished_links]
         self.assertEqual(3, link_tails.count("Namespace__SomeActor_mem_var:isValid [style=dotted]"), msg= \
             "Should have parsed correct number of links which end on this node with no label")
+
+    def test_parse_two_classes_with_rank_same(self) -> None:
+        self.parse_test_input()
+
+        self.assertEqual(1, len(self.parser.node_parser.rank_same_clusters), msg = \
+            "Should have one line of rank=same to print")
+        self.assertEqual("rank=same;Namespace__GreatStruct_calculateSomething;Namespace__SomeActor_mem_var", \
+                         self.parser.node_parser.rank_same_clusters[0], \
+                         msg = "Should have expected rank=same line")


### PR DESCRIPTION
New `**` in link dest label to triple print the link. The rest of the label is replicated across the copies but `graphviz` doesn't produce something nice with it - even if there's only one copy with the label text.